### PR TITLE
Working on ubuntu

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,4 +33,12 @@ when 'debian'
   execute "locale_gen" do
     command "locale-gen"
   end
+when 'ubuntu'
+  node[:localegen][:lang].each do |lang|
+    bash "append_locale" do
+      user "root"
+      environment ({'lang' => lang})
+      code "locale-gen $lang"
+    end
+  end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,6 +18,8 @@
 # limitations under the License.
 #
 
+case node[:platform]
+when 'debian'
 node[:localegen][:lang].each do |lang|
   bash "append_locale" do
     user "root"
@@ -30,4 +32,5 @@ end
 
 execute "locale_gen" do
   command "locale-gen"
+end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,5 +29,5 @@ node[:localegen][:lang].each do |lang|
 end
 
 execute "locale_gen" do
-    command "locale-gen"
+  command "locale-gen"
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,17 +20,17 @@
 
 case node[:platform]
 when 'debian'
-node[:localegen][:lang].each do |lang|
-  bash "append_locale" do
-    user "root"
-    environment ({'lang' => lang})
-    code <<-EOH
-    echo $lang >> /etc/locale.gen
-    EOH
+  node[:localegen][:lang].each do |lang|
+    bash "append_locale" do
+      user "root"
+      environment ({'lang' => lang})
+      code <<-EOH
+      echo $lang >> /etc/locale.gen
+      EOH
+    end
   end
-end
 
-execute "locale_gen" do
-  command "locale-gen"
-end
+  execute "locale_gen" do
+    command "locale-gen"
+  end
 end


### PR DESCRIPTION
locale-gen not working on ubuntu

On Ubuntu, locale-gen accepts lang parameter.
https://help.ubuntu.com/community/Locale#A.28Re-.29Generating_locales

I have tested lucid32 http://files.vagrantup.com/lucid32.box and works fine.
