### PR TITLE
Support Ubuntu 12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.bundle
+.cache
+.kitchen
+bin

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source :rubygems
+
+gem 'test-kitchen'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,132 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    archive-tar-minitar (0.5.2)
+    builder (3.2.0)
+    bunny (0.7.9)
+    chef (10.18.2)
+      bunny (>= 0.6.0, < 0.8.0)
+      erubis
+      highline (>= 1.6.9)
+      json (>= 1.4.4, <= 1.6.1)
+      mixlib-authentication (>= 1.3.0)
+      mixlib-cli (>= 1.1.0)
+      mixlib-config (>= 1.1.2)
+      mixlib-log (>= 1.3.0)
+      mixlib-shellout
+      moneta (< 0.7.0)
+      net-ssh (~> 2.2.2)
+      net-ssh-multi (~> 1.1.0)
+      ohai (>= 0.6.0)
+      rest-client (>= 1.0.4, < 1.7.0)
+      treetop (~> 1.4.9)
+      uuidtools
+      yajl-ruby (~> 1.1)
+    childprocess (0.3.9)
+      ffi (~> 1.0, >= 1.0.11)
+    coderay (1.0.9)
+    erubis (2.7.0)
+    excon (0.19.3)
+    ffi (1.4.0)
+    fog (1.9.0)
+      builder
+      excon (~> 0.14)
+      formatador (~> 0.2.0)
+      mime-types
+      multi_json (~> 1.0)
+      net-scp (~> 1.0.4)
+      net-ssh (>= 2.1.3)
+      nokogiri (~> 1.5.0)
+      ruby-hmac
+    foodcritic (1.7.0)
+      erubis
+      gherkin (~> 2.11.1)
+      gist (~> 3.1.0)
+      nokogiri (~> 1.5.4)
+      pry (~> 0.9.8.4)
+      rak (~> 1.4)
+      treetop (~> 1.4.10)
+      yajl-ruby (~> 1.1.0)
+    formatador (0.2.4)
+    gherkin (2.11.5)
+      json (>= 1.4.6)
+    gist (3.1.1)
+    hashr (0.0.22)
+    highline (1.6.15)
+    i18n (0.6.4)
+    ipaddress (0.8.0)
+    json (1.5.5)
+    librarian (0.0.26)
+      archive-tar-minitar (>= 0.5.2)
+      chef (>= 0.10)
+      highline
+      thor (~> 0.15)
+    log4r (1.1.10)
+    method_source (0.7.1)
+    mime-types (1.21)
+    mixlib-authentication (1.3.0)
+      mixlib-log
+    mixlib-cli (1.2.2)
+    mixlib-config (1.1.2)
+    mixlib-log (1.4.1)
+    mixlib-shellout (1.1.0)
+    moneta (0.6.0)
+    multi_json (1.6.1)
+    net-scp (1.0.4)
+      net-ssh (>= 1.99.1)
+    net-ssh (2.2.2)
+    net-ssh-gateway (1.1.0)
+      net-ssh (>= 1.99.1)
+    net-ssh-multi (1.1)
+      net-ssh (>= 2.1.4)
+      net-ssh-gateway (>= 0.99.0)
+    nokogiri (1.5.6)
+    ohai (6.16.0)
+      ipaddress
+      mixlib-cli
+      mixlib-config
+      mixlib-log
+      mixlib-shellout
+      systemu
+      yajl-ruby
+    polyglot (0.3.3)
+    pry (0.9.8.4)
+      coderay (~> 1.0.5)
+      method_source (~> 0.7.1)
+      slop (>= 2.4.4, < 3)
+    rak (1.4)
+    rest-client (1.6.7)
+      mime-types (>= 1.16)
+    ruby-hmac (0.4.0)
+    slop (2.4.4)
+    systemu (2.5.2)
+    test-kitchen (0.7.0)
+      fog
+      foodcritic (>= 1.4.0)
+      hashr (~> 0.0.20)
+      highline (>= 1.6.9)
+      librarian (~> 0.0.20)
+      mixlib-cli (~> 1.2.2)
+      vagrant (~> 1.0.2)
+      yajl-ruby (~> 1.1.0)
+    thor (0.17.0)
+    treetop (1.4.12)
+      polyglot
+      polyglot (>= 0.3.1)
+    uuidtools (2.1.3)
+    vagrant (1.0.6)
+      archive-tar-minitar (= 0.5.2)
+      childprocess (~> 0.3.1)
+      erubis (~> 2.7.0)
+      i18n (~> 0.6.0)
+      json (~> 1.5.1)
+      log4r (~> 1.1.9)
+      net-scp (~> 1.0.4)
+      net-ssh (~> 2.2.2)
+    yajl-ruby (1.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  test-kitchen

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ Change Log
 ==========
 0.0.1 - Initial version by dan@danhart.co.uk
 
-0.0.2 - Revised by sean@linenine.net (logikal)
+0.0.2 - use only locales from attribute, run locale-gen only when /etc/locale.gen is changed
+
+0.0.3 - Revised by sean@linenine.net (logikal)
 Adds the following:
 * Support for Ubuntu 12
-* Template based locale file - Stop appending to the locale file
-* More idempotency by not running execute unless template has change
+* Support for test-kitchen

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Requirements
 ============
 
 Tested on Debian Squeeze
+Tested on Ubuntu 12 (precise)
 
 Attributes
 ==========
@@ -17,3 +18,14 @@ Usage
 =====
 
 Include the default recipe in your run list.
+
+
+Change Log
+==========
+0.0.1 - Initial version by dan@danhart.co.uk
+
+0.0.2 - Revised by sean@linenine.net (logikal)
+Adds the following:
+* Support for Ubuntu 12
+* Template based locale file - Stop appending to the locale file
+* More idempotency by not running execute unless template has change

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,2 @@
 default[:localegen][:lang] = ["en_GB.UTF-8 UTF-8", "en_GB.ISO-8859-15 ISO-8859-15"]
+default[:localegen][:locale_file] = "/var/lib/locales/supported.d/local"

--- a/files/default/tests/minitest/default_test.rb
+++ b/files/default/tests/minitest/default_test.rb
@@ -1,0 +1,9 @@
+require 'minitest/spec'
+
+describe_recipe 'locale-gen::default' do
+	describe 'configfile' do
+		it 'creates the locale config file' do
+			file(node["localegen"]["locale_file"]).must_exist
+		end
+	end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name			 "locale-gen"
 maintainer       "Dan Hart"
 maintainer_email "dan@danhart.co.uk"
 license          "Apache 2.0"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "dan@danhart.co.uk"
 license          "Apache 2.0"
 description      "Adds new locales and generates them"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.0.2"
+version          "0.0.3"
 
 supports "ubuntu"
 supports "debian"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,12 +18,19 @@
 # limitations under the License.
 #
 
-execute "locale-gen" do
-  action :nothing
-  command "locale-gen"
+if platform?("ubuntu") and node[:lsb][:codename] == "precise" then
+  node.set["localegen"]["locale_file"] = "/var/lib/locales/supported.d/local"
+else
+	node.set["localegen"]["locale_file"] = "/etc/locale.gen"
 end
 
-file "/etc/locale.gen" do
+# declare the execute["local-gen"] before notifying it.
+execute "locale-gen" do
+    command "locale-gen"
+    action :nothing
+end 
+
+file node["localegen"]["locale_file"] do
   action :create
   owner "root"
   group "root"

--- a/test/kitchen/Kitchenfile
+++ b/test/kitchen/Kitchenfile
@@ -1,0 +1,3 @@
+cookbook "locale-gen" do
+
+end


### PR DESCRIPTION
Ubuntu 12 uses a different file to store local locales in. This update checks to see if you're running Ubuntu 12, and does the right thing if you are.

I've also added a template, instead of appending to the locale file every time chef is run.
Template changes now notify locale-gen to run, so subsequent chef runs will not trigger any work if nothing has changed.
