### PR TITLE
Fix for Ubuntu versions

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-if platform?("ubuntu") and node[:lsb][:codename] == "precise" then
+if platform?("ubuntu") then
   node.set["localegen"]["locale_file"] = "/var/lib/locales/supported.d/local"
 else
 	node.set["localegen"]["locale_file"] = "/etc/locale.gen"
@@ -28,7 +28,7 @@ end
 execute "locale-gen" do
     command "locale-gen"
     action :nothing
-end 
+end
 
 file node["localegen"]["locale_file"] do
   action :create


### PR DESCRIPTION
Hi,

As far as I know `/var/lib/locales/supported.d/local` is always used in Ubuntu. I updated your cookbook since it wasn't working on 12.10 and higher
