### PR TITLE
Use default[] instead of node.set[] on locale_file attribute, bump version to 0.0.4

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,7 @@
 default[:localegen][:lang] = ["en_GB.UTF-8 UTF-8", "en_GB.ISO-8859-15 ISO-8859-15"]
-default[:localegen][:locale_file] = "/var/lib/locales/supported.d/local"
+
+if platform?("ubuntu") then
+    default['localegen']['locale_file'] = '/var/lib/locales/supported.d/local'
+else
+    default['localegen']['locale_file'] = '/etc/locale.gen'
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "dan@danhart.co.uk"
 license          "Apache 2.0"
 description      "Adds new locales and generates them"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.0.3"
+version          "0.0.4"
 
 supports "ubuntu"
 supports "debian"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,12 +18,6 @@
 # limitations under the License.
 #
 
-if platform?("ubuntu") then
-  node.set["localegen"]["locale_file"] = "/var/lib/locales/supported.d/local"
-else
-	node.set["localegen"]["locale_file"] = "/etc/locale.gen"
-end
-
 # declare the execute["local-gen"] before notifying it.
 execute "locale-gen" do
     command "locale-gen"


### PR DESCRIPTION
Ensures that it works as expected, and doesn't explicitly overwrite any attributes.
